### PR TITLE
Fix so that default options are overridable

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -45,7 +45,7 @@ function Strategy(options, verify) {
   }
 
   // Merge user options with default options
-  options = Object.assign({}, defaultOptions, options);
+  this.options = Object.assign({}, defaultOptions, options);
 
   passport.Strategy.call(this);
   this.name = 'publicKey';
@@ -66,7 +66,7 @@ util.inherits(Strategy, passport.Strategy);
  */
 Strategy.prototype.authenticate = function(req, options) {
   // Merge user options with default options
-  options = Object.assign({}, defaultOptions, options);
+  options = Object.assign({}, this.options, options);
 
   if (req[options.in] == null) { // Note: "== null" means "=== null or undefined"
     return this.fail({ message: options.badRequestMessage || `Missing credentials` }, 400)


### PR DESCRIPTION
It wasn't possible to override defaultOptions due to the constructor not actually saving the merge of defaultOptions with user supplied options in its instance.